### PR TITLE
Add first docker tag to primary key

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,6 @@ inputs:
     required: true
 
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"
 

--- a/index.js
+++ b/index.js
@@ -34,7 +34,9 @@ const duration = require('parse-duration');
     abort("docker build args require --file")
   }
 
-  const primaryKey = sha256(`${cacheKey} ${dockerBuildArgs} ${sha256File(dockerfile)}`)
+  const firstTag = dockerBuildTags[0]
+  const hash = sha256(`${cacheKey} ${dockerBuildArgs} ${sha256File(dockerfile)}`)
+  const primaryKey = firstTag + hash
   const cachePath = path.join(runnerTemp, "cached-docker-build", primaryKey)
   let cacheHit = false
 


### PR DESCRIPTION
If we cache various dockerfiles, we will know which one to delete and if we have more than one for the same.  Now only show the sha256 in GH caches.

:pray:  Please upate to Node16 
To fix these errors:
![image](https://user-images.githubusercontent.com/249085/225758708-e4278b42-db28-4b5d-a344-fb90e56427fc.png)

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Thank you